### PR TITLE
Edit definition of Trajectory message and remove unused messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,6 @@ find_package(rosidl_default_generators REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/Trajectory.msg"
-  "msg/SensorData.msg"
   "msg/JointAngles.msg"
   "srv/SensorDataRequest.srv"
  )

--- a/msg/SensorData.msg
+++ b/msg/SensorData.msg
@@ -1,1 +1,0 @@
-string data

--- a/msg/Trajectory.msg
+++ b/msg/Trajectory.msg
@@ -1,1 +1,1 @@
-string data
+JointAngles[] trajectory


### PR DESCRIPTION
Creates `Trajectory` message that can be published to the `/trajectory` topic for automatic execution